### PR TITLE
Build site hierarchy for a document from its URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ NEW_RELIC_LICENSE_KEY=see-education-team
 KEY_PREFIX=sitesearch:dev
 ENV=development
 API_KEY=whatever-you-want
+NEW_RELIC_MONITOR_MODE=off

--- a/README.md
+++ b/README.md
@@ -88,7 +88,19 @@ app_1   | 2021-01-12 21:18:07 [sitesearch.indexer] ERROR: Document parser error 
 app_1   | 2021-01-12 21:18:08 [sitesearch.indexer] ERROR: Document parser error -- Skipping 404 page: https://docs.redislabs.com/latest/404.html
 ```
 
-This output is usually normal -- some pages don't have breadcrumbs, and we skip 404 pages.
+This output is normal -- some pages don't have breadcrumbs, and we skip 404 pages.
+
+#### Scheduled indexing
+
+The app indexes on a schedule, every 60 minutes. So if you leave it running, it will reindex once per hour.
+
+#### Manually indexing
+
+While you work, you might want to reindex to test a change to the indexing process.
+
+You have two options to force the app to reindex:
+* Restart the app: `docker-compose restart`
+* Manually trigger reindexing with the `index` CLI command: `docker-compose exec app index`
 
 ### New Relic
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ rq-scheduler==0.10.0
 scrapy==2.3.0
 gevent==20.9.0
 hiredis==1.1.0
-newrelic
+newrelic==6.0.1.155
 --no-binary falcon falcon==2.0.0
 git+https://github.com/RediSearch/redisearch-py.git@master#egg=redisearch

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setuptools.setup(
         'console_scripts': [
             'index=sitesearch.commands.index:index',
             'search=sitesearch.commands.search:search',
-            'scheduler=sitesearch.commands.scheduler:scheduler'
+            'scheduler=sitesearch.commands.scheduler:scheduler',
+            'drop-index=sitesearch.commands.drop_index:drop_index'
         ],
     }
 )

--- a/sitesearch/api/app.py
+++ b/sitesearch/api/app.py
@@ -7,12 +7,14 @@ from .indexer import IndexerResource
 from .health import HealthCheckResource
 
 
+
 def create_app(config=None):
     config = config or Config()
 
     cors = CORS(allow_origins_list=[
         'https://docs.redislabs.com',
-        'http://localhost:1313'
+        'http://localhost:1313',
+        'http://localhost:8000',
     ])
 
     api = falcon.API(middleware=[cors.middleware])

--- a/sitesearch/api/health.py
+++ b/sitesearch/api/health.py
@@ -1,15 +1,12 @@
 import logging
+from sitesearch import keys
 
 from falcon.status_codes import HTTP_503
 from redis.exceptions import ResponseError
 from rq import Queue
-from rq.exceptions import NoSuchJobError
-from rq.job import Job, JobStatus
-from rq.registry import StartedJobRegistry
 
 from sitesearch.config import Config
 from sitesearch.connections import get_search_connection, get_rq_redis_client
-from sitesearch.tasks import JOB_ID, INDEXING_TIMEOUT, index
 from .resource import Resource
 
 config = Config()
@@ -17,16 +14,6 @@ redis_client = get_rq_redis_client()
 search_client = get_search_connection(config.default_search_site.index_name)
 log = logging.getLogger(__name__)
 queue = Queue(connection=redis_client)
-registry = StartedJobRegistry('default', connection=redis_client)
-
-JOB_FINISHED_STATES = (
-    JobStatus.FINISHED,
-    JobStatus.FAILED
-)
-JOB_IN_PROGRESS_STATES = (
-    JobStatus.QUEUED,
-    JobStatus.STARTED
-)
 
 
 class HealthCheckResource(Resource):
@@ -40,29 +27,17 @@ class HealthCheckResource(Resource):
         If there is no index and an indexing job is not in progress,
         this check starts an indexing job in the background.
         """
-        try:
-            status = Job.fetch(JOB_ID, connection=redis_client).get_status()
-        except NoSuchJobError:
-            # Indexing has started if our job is in this registry,
-            # so we don't want to start it again, and the app
-            # shouldn't be available yet.
-            if JOB_ID in registry.get_job_ids():
-                resp.status = HTTP_503
-                return
-            status = None
+        indexing_job_ids = redis_client.smembers(keys.startup_indexing_job_ids())
 
-        if status in JOB_IN_PROGRESS_STATES:
+        if indexing_job_ids:
+            # Indexing is in-progress, so the app shouldn't be available yet.
             resp.status = HTTP_503
             return
 
         try:
             search_client.info()
         except ResponseError as e:
+            # The index doesn't exist -- this may indicate that indexing
+            # hasn't started yet, or else our indexing tasks all failed.
             log.error("Response error: %s", e)
-
-            # We usually get a response error if the index doesn't exist.
-            # If that's the case and we don't have an indexing job in
-            # progress, we should try to reindex.
             resp.status = HTTP_503
-            queue.enqueue(index, self.config.sites, job_id=JOB_ID,
-                          job_timeout=INDEXING_TIMEOUT)

--- a/sitesearch/api/indexer.py
+++ b/sitesearch/api/indexer.py
@@ -1,21 +1,21 @@
 import json
 import logging
 import os
+from sitesearch import keys
 
 from falcon.errors import HTTPUnauthorized
 from rq import Queue
 from rq.job import Job
 from rq.exceptions import NoSuchJobError
 from rq.registry import StartedJobRegistry
+from sitesearch import tasks
 
 from sitesearch.config import Config
-from sitesearch.connections import get_search_connection, get_rq_redis_client
-from sitesearch.tasks import JOB_ID, JOB_STARTED, JOB_NOT_QUEUED, index, INDEXING_TIMEOUT
+from sitesearch.connections import get_rq_redis_client
 from .resource import Resource
 
 config = Config()
 redis_client = get_rq_redis_client()
-search_client = get_search_connection(config.default_search_site.index_name)
 log = logging.getLogger(__name__)
 queue = Queue(connection=redis_client)
 registry = StartedJobRegistry('default', connection=redis_client)
@@ -25,35 +25,54 @@ API_KEY = os.environ['API_KEY']
 
 class IndexerResource(Resource):
     def on_get(self, req, resp):
-        """Start an indexing job."""
-        try:
-            status = Job.fetch(JOB_ID, connection=redis_client).get_status()
-        except NoSuchJobError:
-            if JOB_ID in registry.get_job_ids():
-                status = JOB_STARTED
-            else:
-                status = JOB_NOT_QUEUED
+        """Get job IDs for in-progress indexing tasks."""
+        indexing_job_ids = redis_client.smembers(keys.startup_indexing_job_ids())
+        jobs = []
 
-        resp.body = json.dumps({"job_id": JOB_ID, "status": status})
+        if indexing_job_ids:
+            for job_id in indexing_job_ids:
+                try:
+                    status = Job.fetch(job_id, connection=redis_client).get_status()
+                except NoSuchJobError:
+                    if job_id in registry.get_job_ids():
+                        status = JOB_STARTED
+                    else:
+                        status = JOB_NOT_QUEUED
+                jobs.append({"job_id": job_id, "status": status})
+
+        resp.body = json.dumps({"jobs": jobs})
 
     def on_post(self, req, resp):
         """Start an indexing job."""
         token = req.get_header('Authorization')
         challenges = ['Token']
+        jobs = []
 
         if token is None:
             description = ('Please provide an auth token '
                            'as part of the request.')
             raise HTTPUnauthorized('Auth token required', description, challenges)
 
-        try:
-            job = Job.fetch(JOB_ID, connection=redis_client)
-        except NoSuchJobError:
-            pass
-        else:
-            job.cancel()
+        indexing_job_ids = redis_client.smembers(keys.startup_indexing_job_ids())
 
-        job = queue.enqueue(index, self.config.sites, job_id=JOB_ID,
-                            job_timeout=INDEXING_TIMEOUT)
+        if indexing_job_ids:
+            for job_id in indexing_job_ids:
+                try:
+                    job = Job.fetch(job_id, connection=redis_client)
+                except NoSuchJobError:
+                    pass
+                else:
+                    job.cancel()
 
-        resp.body = json.dumps({"job_id": JOB_ID, "status": job.get_status()})
+        for site in self.config.sites.values():
+            job = queue.enqueue(tasks.index,
+                                args=[site],
+                                kwargs={
+                                    "rebuild_index": True,
+                                    "force": True
+                                },
+                                job_timeout=tasks.INDEXING_TIMEOUT)
+            redis_client.sadd(keys.startup_indexing_job_ids(), job.id)
+            jobs.append({"job_id" :job.id, "status": "started"})
+
+        resp.body = json.dumps({"jobs": jobs})

--- a/sitesearch/commands/drop_index.py
+++ b/sitesearch/commands/drop_index.py
@@ -28,3 +28,6 @@ def drop_index(site):
         redis_client.drop_index()
     except ResponseError:
         log.info("Search index does not exist: %s", site.index_name)
+
+    indexer = Indexer(site)
+    redis_client.redis.srem(indexer.index_name)

--- a/sitesearch/commands/drop_index.py
+++ b/sitesearch/commands/drop_index.py
@@ -2,7 +2,7 @@ import logging
 
 import click
 
-from sitesearch import tasks
+from sitesearch.connections import get_search_connection
 from sitesearch.config import Config
 
 
@@ -10,10 +10,9 @@ config = Config()
 log = logging.getLogger(__name__)
 
 
-@click.option('--rebuild-index', default=False)
 @click.argument('site')
 @click.command()
-def index(site, rebuild_index):
+def drop_index(site):
     """Index the app's configured sites in RediSearch."""
     site = config.sites.get(site)
 
@@ -22,4 +21,5 @@ def index(site, rebuild_index):
         raise click.BadArgumentUsage(
             f"The site you gave does not exist. Valid sites: {valid_sites}")
 
-    tasks.index(site, rebuild_index=rebuild_index, force=True)
+    redis_client = get_search_connection(site.index_name)
+    redis_client.drop_index()

--- a/sitesearch/commands/drop_index.py
+++ b/sitesearch/commands/drop_index.py
@@ -1,6 +1,7 @@
 import logging
 
 import click
+from redis.exceptions import ResponseError
 
 from sitesearch.connections import get_search_connection
 from sitesearch.config import Config
@@ -22,4 +23,8 @@ def drop_index(site):
             f"The site you gave does not exist. Valid sites: {valid_sites}")
 
     redis_client = get_search_connection(site.index_name)
-    redis_client.drop_index()
+
+    try:
+        redis_client.drop_index()
+    except ResponseError:
+        log.info("Search index does not exist: %s", site.index_name)

--- a/sitesearch/commands/index.py
+++ b/sitesearch/commands/index.py
@@ -10,8 +10,8 @@ config = Config()
 log = logging.getLogger(__name__)
 
 
-@click.option('--create-index', default=False)
+@click.option('--rebuild-index', default=False)
 @click.command()
 def index(rebuild_index):
     """Index the app's configured sites in RediSearch."""
-    tasks.index(config.sites, rebuild_index=rebuild_index)
+    tasks.index(config.sites, rebuild_index=rebuild_index, force=True)

--- a/sitesearch/commands/index.py
+++ b/sitesearch/commands/index.py
@@ -8,6 +8,7 @@ from sitesearch.config import Config
 
 config = Config()
 log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
 
 @click.option('--rebuild-index', default=False)

--- a/sitesearch/commands/scheduler.py
+++ b/sitesearch/commands/scheduler.py
@@ -2,8 +2,10 @@ import logging
 
 import click
 from rq_scheduler.scheduler import Scheduler
+from rq import Queue
 
 from sitesearch.connections import get_rq_redis_client
+from sitesearch import keys
 from sitesearch import tasks
 from sitesearch.config import Config
 
@@ -17,29 +19,47 @@ def scheduler():
     """Run rq-scheduler"""
     redis_client = get_rq_redis_client()
     scheduler = Scheduler(connection=redis_client)
+    queue = Queue(connection=redis_client)
 
-    # Create the RediSearch index and begin indexing immediately.
-    # If a previous index exists, delete it.
-    tasks.index(config.sites, rebuild_index=True, force=True)
+    for site in config.sites.values():
+        job = queue.enqueue(tasks.index,
+                            args=[site],
+                            kwargs={
+                                "rebuild_index": True,
+                                "force": True
+                            },
+                            job_timeout=tasks.INDEXING_TIMEOUT)
 
-    # Schedule an indexing job to run every 60 minutes.
-    #
-    # This performs an update-in-place using the existing RediSearch index.
-    #
-    # TODO: We currently don't try to detect if we have outdated content in
-    # the index -- i.e. when we reindexed a site, a URL was leftover in the
-    # index that we didn't find on this round of indexing.
-    #
-    # NOTE: We need to define this here, at the time we run this command,
-    # because there is no deduplication in the cron() method, and this app has
-    # no "exactly once" startup/initialization step that we could use to call
-    # code only once.
-    scheduler.cron(
-        "*/60 * * * *",
-        func=tasks.index,
-        args=[config.sites, False],
-        use_local_timezone=True,
-        timeout=tasks.INDEXING_TIMEOUT
-    )
+        # Track in-progress indexing tasks in a Redis set, so that we can
+        # check if indexing is in-progress. Tasks should remove their
+        # IDs from the set, so that when the set is empty, we think
+        # indexing is done.
+        redis_client.sadd(keys.startup_indexing_job_ids(), job.id)
+
+        # Schedule an indexing job to run every 60 minutes.
+        #
+        # This performs an update-in-place using the existing RediSearch index.
+        #
+        # TODO: We currently don't try to detect if we have outdated content in
+        # the index -- i.e. when we reindexed a site, a URL was leftover in the
+        # index that we didn't find on this round of indexing.
+        #
+        # NOTE: We need to define this here, at the time we run this command,
+        # because there is no deduplication in the cron() method, and this app has
+        # no "exactly once" startup/initialization step that we could use to call
+        # code only once.
+        scheduler.cron(
+            "*/60 * * * *",
+            func=tasks.index,
+            args=[site],
+            kwargs={
+                "rebuild_index": False,
+                "force": False
+            },
+            use_local_timezone=True,
+            timeout=tasks.INDEXING_TIMEOUT
+        )
+
+    redis_client.expire(keys.startup_indexing_job_ids(), tasks.INDEXING_TIMEOUT)
 
     scheduler.run()

--- a/sitesearch/commands/scheduler.py
+++ b/sitesearch/commands/scheduler.py
@@ -20,7 +20,7 @@ def scheduler():
 
     # Create the RediSearch index and begin indexing immediately.
     # If a previous index exists, delete it.
-    tasks.index(config.sites, rebuild_index=True)
+    tasks.index(config.sites, rebuild_index=True, force=True)
 
     # Schedule an indexing job to run every 60 minutes.
     #

--- a/sitesearch/commands/scheduler.py
+++ b/sitesearch/commands/scheduler.py
@@ -40,10 +40,6 @@ def scheduler():
         #
         # This performs an update-in-place using the existing RediSearch index.
         #
-        # TODO: We currently don't try to detect if we have outdated content in
-        # the index -- i.e. when we reindexed a site, a URL was leftover in the
-        # index that we didn't find on this round of indexing.
-        #
         # NOTE: We need to define this here, at the time we run this command,
         # because there is no deduplication in the cron() method, and this app has
         # no "exactly once" startup/initialization step that we could use to call

--- a/sitesearch/commands/scheduler.py
+++ b/sitesearch/commands/scheduler.py
@@ -22,7 +22,7 @@ def scheduler():
     # If a previous index exists, delete it.
     tasks.index(config.sites, rebuild_index=True)
 
-    # Schedule an indexing job to run every 30 minutes.
+    # Schedule an indexing job to run every 60 minutes.
     #
     # This performs an update-in-place using the existing RediSearch index.
     #

--- a/sitesearch/config.py
+++ b/sitesearch/config.py
@@ -2,7 +2,7 @@ import os
 
 from dotenv import load_dotenv
 
-from sitesearch.sites.redis_labs import DOCS_PROD, DOCS_STAGING
+from sitesearch.sites.redis_labs import CORPORATE, DOCS_PROD, DOCS_STAGING, DEVELOPERS, OSS
 
 load_dotenv()
 
@@ -13,9 +13,20 @@ IS_DEV = ENV in ('development', 'test')
 class Config:
     def __init__(self):
         if IS_DEV :
-            self.sites = [DOCS_STAGING]
+            self.sites = {
+                DOCS_STAGING.url: DOCS_STAGING,
+                DEVELOPERS.url: DEVELOPERS,
+                CORPORATE.url: CORPORATE,
+                OSS.url: OSS
+            }
             self.default_search_site = DOCS_STAGING
             return
 
-        self.sites = [DOCS_PROD]
+        self.sites = {
+            DOCS_PROD.url: DOCS_PROD,
+            DEVELOPERS.url: DEVELOPERS,
+            CORPORATE.url: CORPORATE,
+            OSS.url: OSS
+        }
         self.default_search_site = DOCS_PROD
+        self.is_dev = IS_DEV

--- a/sitesearch/indexer.py
+++ b/sitesearch/indexer.py
@@ -328,9 +328,6 @@ class Indexer:
         parts = url.split("/")
         joinable_site_url = self.site.url.rstrip("/")
 
-        if not parts:
-            print("No parts", url)
-
         for i, part in enumerate(parts):
             if i == 0:
                 continue
@@ -338,11 +335,9 @@ class Indexer:
             page = self.seen_urls.get(path_url)
             if page:
                 hierarchy.append(page)
-            else:
-                print('not found', path_url)
 
         if not hierarchy:
-            print('no hierarchy', url)
+            log.debug('URL lacks hierarchy: %s', url)
 
         return hierarchy
 

--- a/sitesearch/keys.py
+++ b/sitesearch/keys.py
@@ -21,5 +21,5 @@ def startup_indexing_job_ids():
     return f"{PREFIX}:startup_indexing_tasks"
 
 
-def site_indexes(url: str):
-    return f"{PREFIX}:{url}:indexes"
+def site_indexes(index_name: str):
+    return f"{PREFIX}:{index_name}:indexes"

--- a/sitesearch/keys.py
+++ b/sitesearch/keys.py
@@ -15,3 +15,11 @@ def last_index(url: str):
 
 def index_name(url: str):
     return f"{PREFIX}:{url}"
+
+
+def startup_indexing_job_ids():
+    return f"{PREFIX}:startup_indexing_tasks"
+
+
+def site_indexes(url: str):
+    return f"{PREFIX}:{url}:indexes"

--- a/sitesearch/models.py
+++ b/sitesearch/models.py
@@ -55,7 +55,8 @@ class SiteConfiguration:
 
     def landing_page(self, query) -> SearchDocument:
         page = self.landing_pages.get(query, None)
-        separator = "" if self.url.endswith("/") else "/"
         if page:
-            page = replace(page, url=f"{self.url}{separator}{page.url}")
+            root_url = self.url.rstrip('/')
+            page_url = page.url.lstrip('/')
+            page = replace(page, url=f"{root_url}/{page_url}")
         return page

--- a/sitesearch/models.py
+++ b/sitesearch/models.py
@@ -34,13 +34,15 @@ Validator = Callable[[SearchDocument], None]
 @dataclass(frozen=True)
 class SiteConfiguration:
     url: str
-    synonym_groups: List[SynonymGroup]
     schema: Tuple[Field]
+    synonym_groups: List[SynonymGroup]
     scorers: Tuple[Scorer]
     validators: Tuple[Validator]
     landing_pages: Dict[str, SearchDocument]
     allow: Tuple[Pattern]
     deny: Tuple[Pattern]
+    allowed_domains: Tuple[str]
+    content_class: str = None
 
     @property
     def all_synonyms(self) -> Set[str]:

--- a/sitesearch/models.py
+++ b/sitesearch/models.py
@@ -42,7 +42,7 @@ class SiteConfiguration:
     allow: Tuple[Pattern]
     deny: Tuple[Pattern]
     allowed_domains: Tuple[str]
-    content_class: str = None
+    content_classes: Tuple[str] = None
 
     @property
     def all_synonyms(self) -> Set[str]:

--- a/sitesearch/query_parser.py
+++ b/sitesearch/query_parser.py
@@ -20,8 +20,6 @@ def parse(query: str, search_site: SiteConfiguration) -> Query:
         if exact_match_query in search_site.all_synonyms:
             query = exact_match_query
 
-    print(query)
-
     return Query(query).summarize(
         'body', context_len=10
     ).highlight(

--- a/sitesearch/query_parser.py
+++ b/sitesearch/query_parser.py
@@ -21,7 +21,7 @@ def parse(query: str, search_site: SiteConfiguration) -> Query:
             query = exact_match_query
 
     return Query(query).summarize(
-        'body', context_len=10
+        'body', context_len=10, num_frags=1
     ).highlight(
         ('title', 'body', 'section_title')
     )

--- a/sitesearch/scorers.py
+++ b/sitesearch/scorers.py
@@ -22,4 +22,5 @@ def boost_top_level_pages(doc: SearchDocument, current_score: float) -> float:
 
     This should result in a boost for top-level pages.
     """
-    return max(current_score - math.log10(len(doc.hierarchy)) / 2, SCORE_FLOOR)
+    length = max(len(doc.hierarchy), 1)
+    return max(current_score - math.log10(length) / 2, SCORE_FLOOR)

--- a/sitesearch/sites/redis_labs.py
+++ b/sitesearch/sites/redis_labs.py
@@ -57,9 +57,10 @@ SYNONYMS = [
 ]
 
 DOCS_PROD = SiteConfiguration(
-    url="https://docs.redislabs.com/latest",
+    url="https://docs.redislabs.com/latest/",
     synonym_groups=SYNONYMS,
     landing_pages=LANDING_PAGES,
+    allowed_domains=('docs.redislabs.com',),
     schema=(
         TextField("title", weight=10),
         TextField("section_title"),
@@ -76,7 +77,8 @@ DOCS_PROD = SiteConfiguration(
         skip_404_page
     ),
     deny=(r'\/release-notes\/', r'.*\.tgz'),
-    allow=(r'\/latest\/',)
+    allow=(),
+    content_class=".main-content"
 )
 
 DOCS_STAGING = dataclasses.replace(
@@ -84,4 +86,83 @@ DOCS_STAGING = dataclasses.replace(
 
     # Uncomment and use your branch to index staging content.
     # url="https://docs.redislabs.com/staging/<your-branch>"
+)
+
+DEVELOPERS = SiteConfiguration(
+    url="https://developer.redislabs.com",
+    synonym_groups=SYNONYMS,
+    landing_pages={},
+    allowed_domains=('developer.redislabs.com',),
+    schema=(
+        TextField("title", weight=10),
+        TextField("section_title"),
+        TextField("body", weight=1.5),
+        TextField("url"),
+        TextField("s", no_stem=True),
+    ),
+    scorers=(),
+    validators=(
+        skip_404_page,
+    ),
+    allow=(),
+    deny=(
+        r'.*\.pdf',
+        r'.*\.tgz',
+    ),
+    content_class=".main-wrapper"
+)
+
+CORPORATE = SiteConfiguration(
+    url="https://redislabs.com",
+    synonym_groups=SYNONYMS,
+    landing_pages=LANDING_PAGES,
+    allowed_domains=('redislabs.com',),
+    schema=(
+        TextField("title", weight=10),
+        TextField("section_title"),
+        TextField("body", weight=1.5),
+        TextField("url"),
+        TextField("s", no_stem=True),
+    ),
+    scorers=(
+        boost_pages,
+        boost_top_level_pages
+    ),
+    validators=(
+        skip_404_page,
+    ),
+    deny=(
+        r'.*\.pdf',
+        r'.*\.tgz',
+        r'\/tag\/.*',
+    ),
+    allow=(),
+    content_class=".bounds-content"
+)
+
+OSS = SiteConfiguration(
+    url="https://redis.io",
+    synonym_groups=SYNONYMS,
+    landing_pages=LANDING_PAGES,
+    allowed_domains=("redis.io",),
+    schema=(
+        TextField("title", weight=10),
+        TextField("section_title"),
+        TextField("body", weight=1.5),
+        TextField("url"),
+        TextField("s", no_stem=True),
+    ),
+    scorers=(
+        boost_pages,
+        boost_top_level_pages
+    ),
+    validators=(
+        skip_404_page,
+    ),
+    deny=(
+        r'.*\.pdf',
+        r'.*\.tgz',
+    ),
+    allow=(),
+    content_class=".site-content"
 )

--- a/sitesearch/sites/redis_labs.py
+++ b/sitesearch/sites/redis_labs.py
@@ -57,7 +57,7 @@ SYNONYMS = [
 ]
 
 DOCS_PROD = SiteConfiguration(
-    url="https://docs.redislabs.com",
+    url="https://docs.redislabs.com/",
     synonym_groups=SYNONYMS,
     landing_pages=LANDING_PAGES,
     schema=(

--- a/sitesearch/sites/redis_labs.py
+++ b/sitesearch/sites/redis_labs.py
@@ -57,7 +57,7 @@ SYNONYMS = [
 ]
 
 DOCS_PROD = SiteConfiguration(
-    url="https://docs.redislabs.com/",
+    url="https://docs.redislabs.com/latest",
     synonym_groups=SYNONYMS,
     landing_pages=LANDING_PAGES,
     schema=(

--- a/sitesearch/sites/redis_labs.py
+++ b/sitesearch/sites/redis_labs.py
@@ -57,7 +57,7 @@ SYNONYMS = [
 ]
 
 DOCS_PROD = SiteConfiguration(
-    url="https://docs.redislabs.com/",
+    url="https://docs.redislabs.com",
     synonym_groups=SYNONYMS,
     landing_pages=LANDING_PAGES,
     schema=(
@@ -83,5 +83,5 @@ DOCS_STAGING = dataclasses.replace(
     DOCS_PROD,
 
     # Uncomment and use your branch to index staging content.
-    # url="https://docs.redislabs.com/staging/docs-with-RediSearch"
+    # url="https://docs.redislabs.com/staging/<your-branch>"
 )

--- a/sitesearch/sites/redis_labs.py
+++ b/sitesearch/sites/redis_labs.py
@@ -78,7 +78,7 @@ DOCS_PROD = SiteConfiguration(
     ),
     deny=(r'\/release-notes\/', r'.*\.tgz'),
     allow=(),
-    content_class=".main-content"
+    content_classes=(".main-content",)
 )
 
 DOCS_STAGING = dataclasses.replace(
@@ -109,7 +109,7 @@ DEVELOPERS = SiteConfiguration(
         r'.*\.pdf',
         r'.*\.tgz',
     ),
-    content_class=".main-wrapper"
+    content_classes=(".markdown", ".margin-vert--md", ".main-wrapper")
 )
 
 CORPORATE = SiteConfiguration(
@@ -137,7 +137,7 @@ CORPORATE = SiteConfiguration(
         r'\/tag\/.*',
     ),
     allow=(),
-    content_class=".bounds-content"
+    content_classes=(".bounds-content", ".bounds-inner")
 )
 
 OSS = SiteConfiguration(
@@ -164,5 +164,5 @@ OSS = SiteConfiguration(
         r'.*\.tgz',
     ),
     allow=(),
-    content_class=".site-content"
+    content_classes=(".site-content",)
 )

--- a/sitesearch/sites/redis_labs_landing_pages.py
+++ b/sitesearch/sites/redis_labs_landing_pages.py
@@ -7,7 +7,7 @@ CLOUD_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["Redis Enterprise Cloud"],
     s="rc",
-    url="latest/rc/",
+    url="/rc/",
     body="Redis Enterprise <b>Cloud</b> delivers a cost-effective, fully "
             "managed Database-as-a-Service (DBaaS) offering, fully hosted on public clouds.",
     type=TYPE_PAGE,
@@ -20,7 +20,7 @@ SOFTWARE_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["Redis Enterprise Software"],
     s="rs",
-    url="latest/rs/",
+    url="/rs/",
     body="Redis Enterprise is a robust, in-memory database platform built by the same people "
          "who develop open-source Redis.",
     type=TYPE_PAGE,
@@ -33,7 +33,7 @@ ACTIVE_ACTIVE_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["Redis Enterprise Software", "Concepts and Architecture", "Geo-Distributed Active-Active Redis Applications"],
     s="rs",
-    url="latest/rs/concepts/intercluster-replication/",
+    url="/rs/concepts/intercluster-replication/",
     body="Developing globally distributed applications can be challenging, as developers "
          "have to think about race conditions and complex combinations of events under "
          "geo-failovers and cross-region write conflicts.",
@@ -48,7 +48,7 @@ FLASH_LANDING_PAGE = SearchDocument(
     hierarchy=["Redis Enterprise Software", "Concepts and Architecture",
                "Memory Architecture in Redis Enterprise Software", "Redis on Flash"],
     s="rs",
-    url="latest/rs/concepts/memory-architecture/redis-flash/",
+    url="/rs/concepts/memory-architecture/redis-flash/",
     body="Redis on Flash (RoF) offers users of Redis Enterprise Software and "
          "Redis Enterprise Cloud the unique ability to have very large Redis "
          "databases but at significant cost savings.",
@@ -62,7 +62,7 @@ REDIS_INSIGHT_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["RedisInsight"],
     s="ri",
-    url="latest/ri/",
+    url="/ri/",
     body="Information on how to install and use RedisInsight, a GUI for administering Redis.",
     type=TYPE_PAGE,
     position=0
@@ -74,7 +74,7 @@ GEARS_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["Redis Modules", "RedisGears"],
     s="modules",
-    url="latest/modules/redisgears/",
+    url="/modules/redisgears/",
     body="RedisGears is an engine for data processing in Redis. RedisGears "
          "supports batch and event-driven processing for Redis data.",
     type=TYPE_PAGE,
@@ -87,7 +87,7 @@ SEARCH_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["Redis Modules", "RediSearch"],
     s="modules",
-    url="latest/modules/redisearch/",
+    url="/modules/redisearch/",
     body="The RediSearch 2.x module is a source-available project that lets you build "
          "powerful searches for open-source Redis databases.",
     type=TYPE_PAGE,
@@ -100,7 +100,7 @@ GRAPH_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["Redis Modules", "RedisGraph"],
     s="modules",
-    url="latest/modules/redisgraph/",
+    url="/modules/redisgraph/",
     body="RedisGraph is the first queryable Property Graph database to use sparse matrices "
          "to represent the adjacency matrix in graphs and linear algebra to query the graph.",
     type=TYPE_PAGE,
@@ -113,7 +113,7 @@ JSON_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["Redis Modules", "RedisJSON"],
     s="modules",
-    url="latest/modules/redisjson/",
+    url="/modules/redisjson/",
     body="Applications developed with the open source version of RedisJSON are 100% "
          "compatible with RedisJSON in Redis Enterprise Software (RS).",
     type=TYPE_PAGE,
@@ -126,7 +126,7 @@ TIMESERIES_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["Redis Modules", "RedisTimeSeries"],
     s="modules",
-    url="latest/modules/redistimeseries/",
+    url="/modules/redistimeseries/",
     body="RedisTimeSeries is a Redis module developed by Redis Labs to enhance your "
          "experience managing time series data with Redis.",
     type=TYPE_PAGE,
@@ -139,7 +139,7 @@ BLOOM_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["Redis Modules", "RedisBloom"],
     s="modules",
-    url="latest/modules/redisbloom/",
+    url="/modules/redisbloom/",
     body="A Bloom filter is a probabilistic data structure which provides an efficient "
          "way to verify that an entry is certainly not in a set.",
     type=TYPE_PAGE,
@@ -152,7 +152,7 @@ AI_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["Redis Modules", "RedisAI"],
     s="modules",
-    url="latest/modules/redisai/",
+    url="/modules/redisai/",
     body="RedisAI is a Redis module for executing Deep Learning/Machine Learning models "
          "and managing their data. ",
     type=TYPE_PAGE,
@@ -165,7 +165,7 @@ MODULES_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["Redis Modules"],
     s="modules",
-    url="latest/modules/",
+    url="/modules/",
     body="Redis Labs develops and packages modules for redis. The modules listed here "
          "are supported with Redis Enterprise Software (RS) clusters and Redis Cloud Pro (RC Pro).",
     type=TYPE_PAGE,
@@ -177,7 +177,7 @@ K8S_LANDING_PAGE = SearchDocument(
     title="Getting Started with Redis Enterprise Software using Kubernetes",
     section_title="",
     hierarchy=["Platforms", "Getting Started with Redis Enterprise Software using Kubernetes"],
-    url="latest/platforms/kubernetes/",
+    url="/platforms/kubernetes/",
     s="platforms",
     body="Getting a Redis Enterprise cluster running on Kubernetes is simple with the Redis Enterprise Operator.",
     type=TYPE_PAGE,

--- a/sitesearch/sites/redis_labs_landing_pages.py
+++ b/sitesearch/sites/redis_labs_landing_pages.py
@@ -126,7 +126,7 @@ TIMESERIES_LANDING_PAGE = SearchDocument(
     section_title="",
     hierarchy=["Redis Modules", "RedisTimeSeries"],
     s="modules",
-    url="/modules/redistimeseries/",
+    url="/modules/redis-timeseries/",
     body="RedisTimeSeries is a Redis module developed by Redis Labs to enhance your "
          "experience managing time series data with Redis.",
     type=TYPE_PAGE,

--- a/sitesearch/tasks.py
+++ b/sitesearch/tasks.py
@@ -15,8 +15,8 @@ JOB_STARTED = 'started'
 INDEXING_TIMEOUT = 60*60  # One hour
 
 
-def index(sites: List[SiteConfiguration], rebuild_index=False):
+def index(sites: List[SiteConfiguration], rebuild_index=False, force=False):
     for site in sites:
         indexer = Indexer(site, rebuild_index=rebuild_index)
-        indexer.index()
+        indexer.index(force=force)
     return True

--- a/sitesearch/tasks.py
+++ b/sitesearch/tasks.py
@@ -1,5 +1,8 @@
 import logging
-from typing import List
+from sitesearch import keys
+from sitesearch.connections import get_rq_redis_client
+
+from rq import get_current_job
 
 from sitesearch.indexer import Indexer
 from sitesearch.models import SiteConfiguration
@@ -9,14 +12,16 @@ log = logging.getLogger(__name__)
 
 # These constants are used by other modules to refer to the
 # state of the `index` task in the queueing/scheduling system.
-JOB_ID = 'index'
 JOB_NOT_QUEUED = 'not_queued'
 JOB_STARTED = 'started'
 INDEXING_TIMEOUT = 60*60  # One hour
 
 
-def index(sites: List[SiteConfiguration], rebuild_index=False, force=False):
-    for site in sites:
-        indexer = Indexer(site, rebuild_index=rebuild_index)
-        indexer.index(force=force)
+def index(site: SiteConfiguration, rebuild_index=False, force=False):
+    redis_client = get_rq_redis_client()
+    job = get_current_job()
+    indexer = Indexer(site, rebuild_index=rebuild_index)
+    indexer.index(force)
+    if job:
+        redis_client.srem(keys.startup_indexing_job_ids(), job.id)
     return True

--- a/sitesearch/transformer.py
+++ b/sitesearch/transformer.py
@@ -34,18 +34,18 @@ def transform_documents(docs: List[Any],
             "body": elide_text(landing_page.body, max_length),
             "url": landing_page.url
         })
-        pages_seen.add((*landing_page.hierarchy, landing_page.title))
+        pages_seen.add(landing_page.url)
 
     for doc in docs:
+        # Only include one result per page
+        if doc.url in pages_seen:
+            continue
+
         try:
             hierarchy = json.loads(doc.hierarchy)
         except (JSONDecodeError, ValueError):
             log.error("Bad hierarchy data for doc: %s", doc)
             hierarchy = []
-
-        # Only include one result per page
-        if (*hierarchy, doc.title) in pages_seen:
-            continue
 
         transformed.append({
             "title": doc.title,
@@ -55,6 +55,6 @@ def transform_documents(docs: List[Any],
             "url": doc.url
         })
 
-        pages_seen.add((*hierarchy, doc.title))
+        pages_seen.add(doc.url)
 
     return transformed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,9 @@ def parse_file():
         with open(file, encoding='utf-8') as f:
             html = f.read()
 
-        return DocumentParser(
-            DOCS_STAGING.url, DOCS_STAGING.validators, DOCS_STAGING.content_class).parse(TEST_URL, html)
+        return DocumentParser(DOCS_STAGING.url, DOCS_STAGING.validators,
+                              DOCS_STAGING.content_classes).parse(
+                                  TEST_URL, html)
 
     yield fn
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def parse_file():
             html = f.read()
 
         return DocumentParser(
-            DOCS_STAGING.url, DOCS_STAGING.validators).parse(TEST_URL, html)
+            DOCS_STAGING.url, DOCS_STAGING.validators, DOCS_STAGING.content_class).parse(TEST_URL, html)
 
     yield fn
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,4 +57,6 @@ def docs(parse_file):
     for doc in docs:
         indexer.index_document(doc)
 
+    indexer.create_index_alias()
+
     yield docs

--- a/tests/test_document_transformer.py
+++ b/tests/test_document_transformer.py
@@ -6,6 +6,7 @@ from sitesearch.transformer import transform_documents
 
 config = Config()
 
+
 def test_transform_documents_elides_body_if_longer_than_max():
     doc = Document(
         id="123",
@@ -38,7 +39,6 @@ def test_transform_documents_retains_body_if_shorter_than_max():
     docs = transform_documents([doc], config.default_search_site, 'test')
 
     assert docs[0]['body'] == "This is the body"
-
 
 def test_transform_documents_decodes_hierarchy():
     doc = Document(

--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -1,13 +1,14 @@
 import time
 
+import pytest
+
 
 def test_no_content(client):
     result = client.simulate_get('/health')
     assert result.status_code == 503
 
 
+@pytest.mark.skip("We need a better way to simulate index existence")
 def test_with_content(docs, client):
-    time.sleep(5)
-    # Should be finished indexing after 5 seconds!
     result = client.simulate_get('/health')
     assert result.status_code == 200

--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -8,5 +8,6 @@ def test_no_content(client):
 
 def test_with_content(docs, client):
     time.sleep(5)
+    # Should be finished indexing after 5 seconds!
     result = client.simulate_get('/health')
     assert result.status_code == 200

--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -8,7 +8,6 @@ def test_no_content(client):
     assert result.status_code == 503
 
 
-@pytest.mark.skip("We need a better way to simulate index existence")
 def test_with_content(docs, client):
     result = client.simulate_get('/health')
     assert result.status_code == 200

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -3,11 +3,11 @@ from unittest import mock
 from unittest.mock import call
 
 import pytest
-
-from sitesearch.config import DOCS_STAGING
 from sitesearch import keys
+from sitesearch.config import DOCS_STAGING
 from sitesearch.errors import ParseError
-from sitesearch.indexer import Indexer, DocumentParser
+from sitesearch.indexer import DocumentParser, Indexer
+from sitesearch.models import SearchDocument
 
 DOCS_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "documents")
@@ -145,3 +145,23 @@ def test_parsing_page_with_links_in_h2s_returns_body_content(parse_file):
     docs = parse_file(FILE_WITH_AN_INDEX)
     for doc in docs:
         assert doc.body is not None
+
+
+def test_build_hierarchy(indexer):
+    indexer.seen_urls = {
+        "https://docs.redislabs.com/latest/1": "One",
+        "https://docs.redislabs.com/latest/1/2": "Two",
+        "https://docs.redislabs.com/latest/1/2/3": "Three",
+    }
+    doc = SearchDocument(
+        doc_id="123",
+        title="Title",
+        section_title="Section",
+        hierarchy=[],
+        s="",
+        url="https://docs.redislabs.com/latest/1/2/3/",
+        body="This is the body",
+        type='page',
+        position=0
+    )
+    assert indexer.build_hierarchy(doc) == ['One', 'Two', 'Three']

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -42,7 +42,7 @@ def parse_file():
             html = f.read()
 
         return DocumentParser(DOCS_STAGING.url, DOCS_STAGING.validators,
-                              DOCS_STAGING.content_class).parse(
+                              DOCS_STAGING.content_classes).parse(
                                   TEST_URL, html)
 
     return fn

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -41,8 +41,9 @@ def parse_file():
         with open(file, encoding='utf-8') as f:
             html = f.read()
 
-        return DocumentParser(
-            DOCS_STAGING.url, DOCS_STAGING.validators).parse(TEST_URL, html)
+        return DocumentParser(DOCS_STAGING.url, DOCS_STAGING.validators,
+                              DOCS_STAGING.content_class).parse(
+                                  TEST_URL, html)
 
     return fn
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -2,7 +2,6 @@ import os
 from unittest import mock
 from unittest.mock import call
 
-from bs4 import BeautifulSoup
 import pytest
 
 from sitesearch.config import DOCS_STAGING
@@ -71,13 +70,13 @@ def test_indexer_indexes_page_document(index_file):
         'doc_id': f'{TEST_URL}:Database Persistence with Redis Enterprise Software',
         'title': 'Database Persistence with Redis Enterprise Software',
         'section_title': '',
-        'hierarchy': '["Redis Enterprise Software", "Concepts and Architecture", "Data Access Architecture", "Database Persistence with Redis Enterprise Software"]',
+        'hierarchy': '[]',
         'url': TEST_URL,
         's': 'test',
         'body': 'All data is stored and managed exclusively in either RAM or RAM + Flash Memory (Redis on Flash) and therefore, is at risk of being lost upon a\xa0process or server failure.\xa0As Redis Enterprise Software is not just a caching solution, but also a full-fledged database, persistence to disk is critical. Therefore, Redis Enterprise Software supports persisting data to disk on a per-database basis and in multiple ways. There are two options for persistence:  Append Only File (AOF) - A continuous writing of data to disk Snapshot (RDB) - An automatic periodic snapshot writing to disk  Data persistence, via either mechanism, is used solely to rehydrate the database if the database process fails for any reason. It is not a replacement for backups, but something you do in addition to backups. To disable data persistence, select None. AOF writes the latest ‘write’ commands into a file every second, it resembles a traditional RDBMS’s redo log, if you are familiar with that. This file can later be ‘replayed’ in order to recover from a crash. A snapshot (RDB) on the other hand, is performed every one, six, or twelve hours. The snapshot is a dump of the data and while there is a potential of losing up to one hour of data, it is dramatically faster to recover from a snapshot compared to AOF recovery. Persistence can be configured either at time of database creation or by editing an existing database’s configuration. While the persistence model can be changed dynamically, just know that it can take time for your database to switch from one persistence model to the other. It depends on what you are switching from and to, but also on the size of your database. Note: For performance reasons, if you are going to be using AOF, it is highly recommended to make sure replication is enabled for that database as well. When these two features are enabled, persistence is performed\xa0on the database slave and does not impact performance on the master. Options for configuring data persistence There are six\xa0options for persistence in Redis Enterprise Software:    Options Description     None Data is not persisted to disk at all.   Append Only File (AoF) on every write Data is fsynced to disk with every write.   Append Only File (AoF) one second Data is fsynced to disk every second.   Snapshot every 1 hour A snapshot of the database is created every hour.   Snapshot every 6 hours A snapshot of the database is created every 6 hours.   Snapshot every 12 hours A snapshot of the database is created every 12 hours.    The first thing you need to do is determine if you even need persistence. Persistence is used to recover from a catastrophic failure, so make sure that you need to incur the overhead of persistence before you select it. If the database is being used as a cache, then you may not need persistence. If you do need persistence, then you need to identify\xa0which is the best type for your use case. Append only file (AOF) vs snapshot (RDB) Now that you know the available options, to assist in making a decision on which option is right for your use case, here is a table about the two:    Append Only File (AOF) Snapshot (RDB)     More resource intensive Less resource\xa0intensive   Provides better durability (recover the latest point in time) Less durable   Slower time to recover (Larger files) Faster recovery time   More disk space required (files tend to grow large and require compaction) Requires less resource (I/O once every several hours and no compaction required)    Data persistence and Redis on Flash If you are enabling data persistence for databases running on Redis Enterprise Flash, by default both master and slave shards are configured to write to disk. This is unlike a standard Redis Enterprise Software database where only the slave shards persist to disk. This master and slave dual data persistence with replication is done to better protect the database against node failures. Flash-based databases are expected to hold larger datasets and repair times for shards can be longer under node failures. Having dual-persistence provides better protection against failures under these longer repair times. However, the dual data persistence with replication adds some processor and network overhead, especially in the case of cloud configurations with persistent storage that is network attached (e.g. EBS-backed volumes in AWS). There may be times where performance is critical for your use case and you don’t want to risk data persistence adding latency. If that is the case, you can disable data-persistence on the master shards using the following\xa0rladmin command: rladmin tune db db: master_persistence disabled     Page Contents   Options for configuring data persistence   Append only file (AOF) vs snapshot (RDB)   Data persistence and Redis on Flash',
         'type': 'page',
         'position': 0,
-        '__score': 0.6989700043360187
+        '__score': 1
     }
     key = keys.document(DOCS_STAGING.url, expected_doc['doc_id'])
     indexer.search_client.redis.hset.assert_any_call(key, mapping=expected_doc)
@@ -90,37 +89,37 @@ def test_indexer_indexes_page_section_documents(index_file):
             'doc_id': f'{TEST_URL}:Database Persistence with Redis Enterprise Software:Options for configuring data persistence:0',
             'title': 'Database Persistence with Redis Enterprise Software',
             'section_title': 'Options for configuring data persistence',
-            'hierarchy': '["Redis Enterprise Software", "Concepts and Architecture", "Data Access Architecture", "Database Persistence with Redis Enterprise Software"]',
+            'hierarchy': '[]',
             'url': TEST_URL,
             's': 'test',
             'body': 'There are six\xa0options for persistence in Redis Enterprise Software:    Options Description     None Data is not persisted to disk at all.   Append Only File (AoF) on every write Data is fsynced to disk with every write.   Append Only File (AoF) one second Data is fsynced to disk every second.   Snapshot every 1 hour A snapshot of the database is created every hour.   Snapshot every 6 hours A snapshot of the database is created every 6 hours.   Snapshot every 12 hours A snapshot of the database is created every 12 hours.    The first thing you need to do is determine if you even need persistence. Persistence is used to recover from a catastrophic failure, so make sure that you need to incur the overhead of persistence before you select it. If the database is being used as a cache, then you may not need persistence. If you do need persistence, then you need to identify\xa0which is the best type for your use case.',
             'type': 'section',
             'position': 0,
-            '__score': 0.4489700043360188,
+            '__score': 0.75,
         },
         {
             'doc_id': f'{TEST_URL}:Database Persistence with Redis Enterprise Software:Append only file (AOF) vs snapshot (RDB):1',
             'title': 'Database Persistence with Redis Enterprise Software',
             'section_title': 'Append only file (AOF) vs snapshot (RDB)',
-            'hierarchy': '["Redis Enterprise Software", "Concepts and Architecture", "Data Access Architecture", "Database Persistence with Redis Enterprise Software"]',
+            'hierarchy': '[]',
             'url': TEST_URL,
             's': 'test',
             'body': 'Now that you know the available options, to assist in making a decision on which option is right for your use case, here is a table about the two:    Append Only File (AOF) Snapshot (RDB)     More resource intensive Less resource\xa0intensive   Provides better durability (recover the latest point in time) Less durable   Slower time to recover (Larger files) Faster recovery time   More disk space required (files tend to grow large and require compaction) Requires less resource (I/O once every several hours and no compaction required)',
             'type': 'section',
             'position': 1,
-            '__score':  0.4489700043360188,
+            '__score':  0.75,
         },
         {
             'doc_id': f'{TEST_URL}:Database Persistence with Redis Enterprise Software:Data persistence and Redis on Flash:2',
             'title': 'Database Persistence with Redis Enterprise Software',
             'section_title': 'Data persistence and Redis on Flash',
             's': 'test',
-            'hierarchy': '["Redis Enterprise Software", "Concepts and Architecture", "Data Access Architecture", "Database Persistence with Redis Enterprise Software"]',
+            'hierarchy': '[]',
             'url': TEST_URL,
             'body': 'If you are enabling data persistence for databases running on Redis Enterprise Flash, by default both master and slave shards are configured to write to disk. This is unlike a standard Redis Enterprise Software database where only the slave shards persist to disk. This master and slave dual data persistence with replication is done to better protect the database against node failures. Flash-based databases are expected to hold larger datasets and repair times for shards can be longer under node failures. Having dual-persistence provides better protection against failures under these longer repair times. However, the dual data persistence with replication adds some processor and network overhead, especially in the case of cloud configurations with persistent storage that is network attached (e.g. EBS-backed volumes in AWS). There may be times where performance is critical for your use case and you don’t want to risk data persistence adding latency. If that is the case, you can disable data-persistence on the master shards using the following\xa0rladmin command: rladmin tune db db: master_persistence disabled',
             'type': 'section',
             'position': 2,
-            '__score': 0.4489700043360188
+            '__score': 0.75
         }
     ]
 
@@ -131,11 +130,6 @@ def test_indexer_indexes_page_section_documents(index_file):
         assert indexer.search_client.redis.hset.call_args_list[i] == call(key, mapping=doc)
 
 
-def test_document_parser_skips_pages_without_breadcrumbs(parse_file):
-    with pytest.raises(ParseError):
-        parse_file(FILE_WITHOUT_BREADCRUMBS)
-
-
 def test_document_parser_skips_pages_without_title(parse_file):
     with pytest.raises(ParseError):
         parse_file(FILE_WITHOUT_TITLE)
@@ -144,30 +138,6 @@ def test_document_parser_skips_pages_without_title(parse_file):
 def test_document_parser_skips_release_notes(parse_file):
     with pytest.raises(ParseError):
         parse_file(FILE_RELEASE_NOTES)
-
-
-def test_document_parser_extracts_one_page():
-    html = BeautifulSoup("""
-    <div id="breadcrumbs" itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb">
-          <span class="links">
-            <a href="../" class="highlight">Redis Labs Documentation</a> <span>&gt;</span> Platforms
-          </span>
-        </div>
-    """, 'html.parser')
-    assert DocumentParser(DOCS_STAGING.url, DOCS_STAGING.validators).extract_hierarchy(
-        html) == ["Platforms"]
-
-
-def test_document_parser_extracts_multiple_pages():
-    html = BeautifulSoup("""
-        <div id="breadcrumbs" itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb">
-          <span class="links">
-            <a href="../../" class="highlight">Redis Labs Documentation</a> <span>&gt;</span> <a href="../../rc/" class="highlight">Redis Enterprise Cloud</a> <span>&gt;</span> How Tos
-          </span>
-        </div>
-    """, 'html.parser')
-    assert DocumentParser(DOCS_STAGING.url, DOCS_STAGING.validators).extract_hierarchy(
-        html) == ["Redis Enterprise Cloud", "How Tos"]
 
 
 def test_parsing_page_with_links_in_h2s_returns_body_content(parse_file):


### PR DESCRIPTION
This change moves from building the site hierarchy for a document (i.e., the list of all pages 'above' it) from a "breadcrumbs" div found on the Redis Labs Documentation site, to constructing the hierarchy from a document's URL.