### PR TITLE
Fix stale document fragments by md5-hashing content

### DIFF
--- a/sitesearch/indexer.py
+++ b/sitesearch/indexer.py
@@ -1,15 +1,17 @@
 import datetime
 import json
+import hashlib
 import logging
 import multiprocessing
 import time
 from dataclasses import asdict
 from queue import Queue
 from threading import Thread
-from typing import Dict, List, Callable, Tuple
+from typing import Dict, List, Callable, Tuple, Set
 from redis import ResponseError
 
 import redis.exceptions
+from redisearch.query import Query
 import scrapy
 from bs4 import BeautifulSoup, element
 from redisearch import Client, IndexDefinition
@@ -30,6 +32,8 @@ DEBOUNCE_SECONDS = 60 * 5  # Five minutes
 SYNUPDATE_COMMAND = 'FT.SYNUPDATE'
 TWO_HOURS = 60*60*2
 INDEXING_LOCK_TIMEOUT = 60*60
+SECTION_ID =  "{url}:section:{hash}"
+PAGE_ID =  "{url}:page:{hash}"
 
 Scorer = Callable[[SearchDocument, float], None]
 ScorerList = List[Scorer]
@@ -38,6 +42,11 @@ Validator = Callable[[SearchDocument], None]
 ValidatorList = List[Validator]
 
 log = logging.getLogger(__name__)
+
+
+def md5(string: str):
+    """Return an md5 digest for an input string."""
+    return hashlib.md5(string.encode("utf-8")).hexdigest()
 
 
 class DebounceError(Exception):
@@ -107,10 +116,15 @@ class DocumentParser:
 
             body = self.prepare_text(
                 BeautifulSoup('\n'.join(page), 'html.parser').get_text())
-            _id = f"{doc.url}:{doc.title}:{part_title}:{i}"
+
+            # Hash the body, title, and position of the section to help
+            # detect stale section documents after indexing is complete.
+            doc_hash = md5("".join([body, part_title, str(i)]))
+
+            doc_id = SECTION_ID.format(url=doc.url, hash=doc_hash)
 
             docs.append(
-                SearchDocument(doc_id=_id,
+                SearchDocument(doc_id=doc_id,
                                title=doc.title,
                                hierarchy=doc.hierarchy,
                                s=doc.s,
@@ -163,7 +177,14 @@ class DocumentParser:
             h2s = content.find_all('h3')
 
         body = self.prepare_text(content.get_text(), True)
-        doc = SearchDocument(doc_id=f"{url}:{title}",
+
+        # Hash the body, title, and position of the page to help detect stale
+        # page documents after indexing is complete.
+        doc_hash = md5("".join([body, title]))
+
+        doc_id = PAGE_ID.format(url=url, hash=doc_hash)
+
+        doc = SearchDocument(doc_id=doc_id,
                              title=title,
                              section_title="",
                              hierarchy=[],
@@ -306,6 +327,10 @@ class Indexer:
         # segment of its URL to known URLs.
         self.seen_urls: Dict[str, str] = {}
 
+        # This is the set of all known document IDs. We'll use this to remove
+        # outdated documents from the index.
+        self.seen_ids: Set[str] = set()
+
     @property
     def url(self):
         return self.site.url
@@ -395,6 +420,42 @@ class Indexer:
         for idx in old_indexes:
             self.redis.execute_command('FT.DROPINDEX', idx)
 
+    def clear_old_hashes(self):
+        """
+        Delete any stale Hashes from the index.
+
+        Stale Hashes are those whose IDs exist in the search index but not in
+        the latest set of seen IDs after scraping a site.
+
+        Every Hash ID includes both the URL of the page it came from and a hash
+        of the page's or section's content. When the content of a page or
+        section we're tracking in the index changes on the site, we'll get a new
+        Hash ID. Because the ID will differ from the one we've already seen,
+        the old Hash will show up as stale, and we can delete it.
+        """
+        all_hash_ids = set()
+        offset = 0
+        iter_by = 200
+
+        # Get the set of all Hash IDs that this index knows about.
+        while True:
+            q = Query("*").paging(offset, iter_by).return_fields("doc_id")
+            existing_docs = self.search_client.search(q).docs
+            if not existing_docs: # No more documents
+                break
+            all_hash_ids |= {getattr(d, 'doc_id', None) for d in existing_docs}
+            offset += iter_by
+
+        stale_ids = all_hash_ids - self.seen_ids
+        stale_ids.discard(None)
+
+        log.warning("Deleting stale IDs: %s", stale_ids)
+
+        # Remove the stale Hashes.
+        if stale_ids:
+            keys = [self.keys.document(self.url, id) for id in stale_ids]
+            self.redis.delete(*keys)
+
     def create_index_alias(self):
         """
         Switch the current alias to point to the new index and delete old indexes.
@@ -409,36 +470,6 @@ class Indexer:
             self.search_client.aliasadd(self.index_alias)
 
         self.clear_old_indexes()
-
-    def cleanup_urls(self):
-        """
-        Remove all Hashes for any URL that we previously indexed but is now
-        missing from the indexed site (because e.g., it was deleted from the
-        site).
-
-        Without special handling for this situation, we will retain Hashes
-        for a URL in the search index even if that URL is removed from the
-        site we are indexing.
-
-        To account for these stale URLs, we will keep a Set in Redis of all
-        the "current" indexed URLs for a site every time we index. Then, each
-        time we index the site, we'll take the difference of the Set of
-        current URLs and the Set of "new" URLs we just indexed. The result is
-        the Set of stale URLs, and we'll remove all Hashes for those URLs --
-        thus, we'll remove them from the search index, which follows Hashes.
-        """
-        current_urls_key = self.keys.site_urls_current(self.index_alias)
-        new_urls_key = self.keys.site_urls_new(self.index_alias)
-        old_urls = self.redis.sdiff(current_urls_key, new_urls_key)
-
-        with self.redis.pipeline(transaction=False) as p:
-            for url in old_urls:
-                # A URL can have multiple self.keys.if it had H2s, so here we scan
-                # through all of the URLs document self.keys.and delete them.
-                for doc_key in self.redis.scan_iter(self.keys.document(url, "*")):
-                    p.delete(doc_key)
-            p.rename(new_urls_key, current_urls_key)
-            p.execute()
 
     def build_hierarchy(self, doc: SearchDocument):
         """
@@ -522,6 +553,7 @@ class Indexer:
             if url_without_slash == self.site.url.rstrip("/"):
                 return
             self.seen_urls[url_without_slash] = item.title
+            self.seen_ids |= {item.doc_id}
             docs_to_process.put(item)
 
         def index_documents():
@@ -546,7 +578,7 @@ class Indexer:
                            datetime.datetime.now().timestamp())
             docs_to_process.join()
             self.create_index_alias()
-            self.cleanup_urls()
+            self.clear_old_hashes()
             self.redis.delete(self.lock)
 
         dispatcher.connect(enqueue_document, signal=signals.item_scraped)

--- a/sitesearch/sites/redis_labs.py
+++ b/sitesearch/sites/redis_labs.py
@@ -1,5 +1,5 @@
 import dataclasses
-from redisearch.client import TextField
+from redisearch.client import TagField, TextField
 
 from sitesearch.models import SiteConfiguration, SynonymGroup
 from sitesearch.scorers import boost_pages, boost_top_level_pages
@@ -67,6 +67,7 @@ DOCS_PROD = SiteConfiguration(
         TextField("body", weight=1.5),
         TextField("url"),
         TextField("s", no_stem=True),
+        TagField("doc_id")
     ),
     scorers=(
         boost_pages,

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,7 +1,6 @@
 import os
 from unittest import mock
 from unittest.mock import call
-import ipdb
 
 import pytest
 
@@ -76,7 +75,7 @@ def test_indexer_indexes_page_document(index_file, keys):
     indexer = index_file(FILE_WITH_SECTIONS)
     expected_doc = {
         'doc_id':
-        f'{TEST_URL}:Database Persistence with Redis Enterprise Software',
+        f'{TEST_URL}:page:c34e3cb81555c9fa4346342034476dd7',
         'title': 'Database Persistence with Redis Enterprise Software',
         'section_title': '',
         'hierarchy': '[]',
@@ -95,8 +94,7 @@ def test_indexer_indexes_page_document(index_file, keys):
 def test_indexer_indexes_page_section_documents(index_file, keys):
     indexer = index_file(FILE_WITH_SECTIONS)
     expected_section_docs = [{
-        'doc_id':
-        f'{TEST_URL}:Database Persistence with Redis Enterprise Software:Options for configuring data persistence:0',
+        'doc_id': f'{TEST_URL}:section:299d6e11b67f34e8a0d84347ae5efbd7',
         'title': 'Database Persistence with Redis Enterprise Software',
         'section_title': 'Options for configuring data persistence',
         'hierarchy': '[]',
@@ -108,8 +106,7 @@ def test_indexer_indexes_page_section_documents(index_file, keys):
         'position': 0,
         '__score': 0.75,
     }, {
-        'doc_id':
-        f'{TEST_URL}:Database Persistence with Redis Enterprise Software:Append only file (AOF) vs snapshot (RDB):1',
+        'doc_id': f'{TEST_URL}:section:f62925eb9d8dca6774a8db54459cf716',
         'title': 'Database Persistence with Redis Enterprise Software',
         'section_title': 'Append only file (AOF) vs snapshot (RDB)',
         'hierarchy': '[]',
@@ -121,8 +118,7 @@ def test_indexer_indexes_page_section_documents(index_file, keys):
         'position': 1,
         '__score': 0.75,
     }, {
-        'doc_id':
-        f'{TEST_URL}:Database Persistence with Redis Enterprise Software:Data persistence and Redis on Flash:2',
+        'doc_id': f'{TEST_URL}:section:4a3ad21413bc98fb35e68c5ef67651c6',
         'title': 'Database Persistence with Redis Enterprise Software',
         'section_title': 'Data persistence and Redis on Flash',
         's': 'test',
@@ -182,8 +178,7 @@ def test_indexer_indexes_sections_from_h3s(index_file, keys):
     indexer = index_file(FILE_WITH_H3s)
 
     expected_section_docs = [{
-        'doc_id':
-        'https://docs.redislabs.com/latest//test:RedisBloom Tutorial',
+        'doc_id': f'{TEST_URL}:page:5a6938363f1cb38ef2eec5397c4e67cc',
         'title': 'RedisBloom Tutorial',
         'section_title': '',
         'hierarchy': '[]',
@@ -195,8 +190,7 @@ def test_indexer_indexes_sections_from_h3s(index_file, keys):
         'position': 0,
         '__score': 1.0
     }, {
-        'doc_id':
-        'https://docs.redislabs.com/latest//test:RedisBloom Tutorial::0',
+        'doc_id': f'{TEST_URL}:section:113820cc765e7328919bc24f7847482c',
         'title': 'RedisBloom Tutorial',
         'section_title': '',
         'hierarchy': '[]',
@@ -208,8 +202,7 @@ def test_indexer_indexes_sections_from_h3s(index_file, keys):
         'position': 0,
         '__score': 0.75
     }, {
-        'doc_id':
-        'https://docs.redislabs.com/latest//test:RedisBloom Tutorial::1',
+        'doc_id': f'{TEST_URL}:section:0c0fe866d8e3ee6b792aed7c3738f4f6',
         'title': 'RedisBloom Tutorial',
         'section_title': '',
         'hierarchy': '[]',
@@ -221,8 +214,7 @@ def test_indexer_indexes_sections_from_h3s(index_file, keys):
         'position': 1,
         '__score': 0.75
     }, {
-        'doc_id':
-        'https://docs.redislabs.com/latest//test:RedisBloom Tutorial::2',
+        'doc_id': f'{TEST_URL}:section:2178f498278a818fa1e0b08206a2347e',
         'title': 'RedisBloom Tutorial',
         'section_title': '',
         'hierarchy': '[]',
@@ -234,8 +226,7 @@ def test_indexer_indexes_sections_from_h3s(index_file, keys):
         'position': 2,
         '__score': 0.75
     }, {
-        'doc_id':
-        'https://docs.redislabs.com/latest//test:RedisBloom Tutorial::3',
+        'doc_id': f'{TEST_URL}:section:f7eef8eb8ad1b02ab6f269da416ae08a',
         'title': 'RedisBloom Tutorial',
         'section_title': '',
         'hierarchy': '[]',
@@ -247,8 +238,7 @@ def test_indexer_indexes_sections_from_h3s(index_file, keys):
         'position': 3,
         '__score': 0.75
     }, {
-        'doc_id':
-        'https://docs.redislabs.com/latest//test:RedisBloom Tutorial::4',
+        'doc_id': f'{TEST_URL}:section:14094b624de5c096352862568e38516c',
         'title': 'RedisBloom Tutorial',
         'section_title': '',
         'hierarchy': '[]',


### PR DESCRIPTION
Previously, we stored document fragments with IDs like
`<title>:<position-in-document>`. This provided no way to resolve stale
data if a fragment moved from one page to another or disappeared
completely from an indexed site.

Now, we index pages and sections with an ID derived from an md5 hash of
text of a fragment and page's title and content.

We use these md5 hashes to resolve stale data after indexing and delete
any outdated Hashes.